### PR TITLE
Add Arrow-kt's Either type support

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -18,10 +18,13 @@ kotlin {
         nodejs()
     }
 
-    @OptIn(ExperimentalWasmDsl::class)
-    wasmJs {
-        binaries.executable()
-        nodejs()
+    if (project.name != "kotlin-retry-either") {
+        // arrow-kt is not available for these targets
+        @OptIn(ExperimentalWasmDsl::class)
+        wasmJs {
+            binaries.executable()
+            nodejs()
+        }
     }
 
     /* https://kotlinlang.org/docs/native-target-support.html#tier-1 */
@@ -49,14 +52,18 @@ kotlin {
 
     /* https://kotlinlang.org/docs/native-target-support.html#tier-3 */
 
-    androidNativeArm32()
-    androidNativeArm64()
-    androidNativeX86()
-    androidNativeX64()
+
+    if (project.name != "kotlin-retry-either") {
+        // arrow-kt is not available for these targets
+        androidNativeArm32()
+        androidNativeArm64()
+        androidNativeX86()
+        androidNativeX64()
+
+        watchosDeviceArm64()
+    }
 
     mingwX64()
-
-    watchosDeviceArm64()
 
     sourceSets {
         all {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 kotlin = "1.9.22"
 kotlin-coroutines = "1.8.0"
 kotlin-result = "2.0.0"
+arrow = "1.2.4"
 mockk = "1.13.10"
 versions-plugin = "0.51.0"
 
@@ -10,6 +11,7 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 kotlin-result = { module = "com.michael-bull.kotlin-result:kotlin-result", version.ref = "kotlin-result" }
+arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [plugins]

--- a/kotlin-retry-either/build.gradle.kts
+++ b/kotlin-retry-either/build.gradle.kts
@@ -1,0 +1,25 @@
+description = "Extensions for integrating with arrow-kt Either type."
+
+plugins {
+    id("kotlin-conventions")
+    id("publish-conventions")
+}
+
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":kotlin-retry"))
+                api(libs.arrow.core)
+                implementation(libs.kotlin.coroutines.core)
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation(project(":kotlin-retry"))
+                implementation(libs.kotlin.coroutines.test)
+            }
+        }
+    }
+}

--- a/kotlin-retry-either/src/commonMain/kotlin/com/github/michaelbull/retry/result/Retry.kt
+++ b/kotlin-retry-either/src/commonMain/kotlin/com/github/michaelbull/retry/result/Retry.kt
@@ -1,0 +1,54 @@
+package com.github.michaelbull.retry.result
+
+import arrow.core.Either
+import com.github.michaelbull.retry.attempt.Attempt
+import com.github.michaelbull.retry.attempt.firstAttempt
+import com.github.michaelbull.retry.instruction.ContinueRetrying
+import com.github.michaelbull.retry.instruction.RetryInstruction
+import com.github.michaelbull.retry.instruction.StopRetrying
+import com.github.michaelbull.retry.policy.RetryPolicy
+import kotlinx.coroutines.delay
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * Calls the specified function [block] and returns its [Either], handling any [Either.Left] returned from the [block] function
+ * execution retrying the invocation according to [instructions][RetryInstruction] from the [policy].
+ */
+public suspend inline fun <A, B> retry(policy: RetryPolicy<A>, block: () -> Either<A, B>): Either<A, B> {
+    contract {
+        callsInPlace(block, InvocationKind.AT_LEAST_ONCE)
+    }
+
+    var attempt: Attempt? = null
+
+    while (true) {
+        val result = block()
+        result.fold({ error ->
+            if (attempt == null) {
+                attempt = firstAttempt()
+            }
+            attempt?.let { currentAttempt ->
+                val failedAttempt = currentAttempt.failedWith(error)
+                when (val instruction = policy(failedAttempt)) {
+                    StopRetrying -> {
+                        return result
+                    }
+
+                    ContinueRetrying -> {
+                        currentAttempt.retryImmediately()
+                    }
+
+                    else -> {
+                        val (delayMillis) = instruction
+                        delay(delayMillis)
+                        currentAttempt.retryAfter(delayMillis)
+                    }
+                }
+            }
+        }, {
+            // When the result is right, return it
+            return result
+        })
+    }
+}

--- a/kotlin-retry-either/src/commonMain/kotlin/com/github/michaelbull/retry/result/RunRetrying.kt
+++ b/kotlin-retry-either/src/commonMain/kotlin/com/github/michaelbull/retry/result/RunRetrying.kt
@@ -1,0 +1,19 @@
+package com.github.michaelbull.retry.result
+
+import arrow.core.Either
+import com.github.michaelbull.retry.instruction.RetryInstruction
+import com.github.michaelbull.retry.policy.RetryPolicy
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * Calls the specified function [block] and returns its [Either], handling any [Either.Left] returned from the [block] function
+ * execution retrying the invocation according to [instructions][RetryInstruction] from the [policy].
+ */
+public suspend inline fun <A, B> runRetrying(policy: RetryPolicy<A>, block: () -> Either<A, B>): Either<A, B> {
+    contract {
+        callsInPlace(block, InvocationKind.AT_LEAST_ONCE)
+    }
+
+    return retry(policy, block)
+}

--- a/kotlin-retry-either/src/commonTest/kotlin/com/github/michaelbull/retry/result/EitherTest.kt
+++ b/kotlin-retry-either/src/commonTest/kotlin/com/github/michaelbull/retry/result/EitherTest.kt
@@ -1,0 +1,217 @@
+package com.github.michaelbull.retry.result
+
+import arrow.core.Either
+import com.github.michaelbull.retry.policy.constantDelay
+import com.github.michaelbull.retry.policy.continueIf
+import com.github.michaelbull.retry.policy.stopAtAttempts
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+class EitherTest {
+
+    private data class AttemptsError(val attempts: Int)
+
+    @Test
+    fun retryToAttemptLimit() = runTest {
+        val fiveTimes = stopAtAttempts<AttemptsError>(5)
+        var attempts = 0
+
+        val result = retry(fiveTimes) {
+            attempts++
+
+            if (attempts < 5) {
+                Either.Left(AttemptsError(attempts))
+            } else {
+                Either.Right(Unit)
+            }
+        }
+
+        assertEquals(Either.Right(Unit), result)
+        assertEquals(5, attempts)
+    }
+
+    @Test
+    fun retryExhaustingAttemptLimit() = runTest {
+        val tenTimes = stopAtAttempts<AttemptsError>(10)
+        var attempts = 0
+
+        val result = retry(tenTimes) {
+            attempts++
+
+            if (attempts < 15) {
+                Either.Left(AttemptsError(attempts))
+            } else {
+                Either.Right(Unit)
+            }
+        }
+
+        assertEquals(Either.Left(AttemptsError(10)), result)
+        assertEquals(10, attempts)
+    }
+
+    @Test
+    fun retryThrowsCancellationException() = runTest {
+        val tenTimes = stopAtAttempts<Unit>(10)
+
+        assertFailsWith<CancellationException> {
+            retry(tenTimes) {
+                Either.Right(Unit).also {
+                    throw CancellationException()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun retryStopsAfterCancellation() = runTest {
+        val fiveTimes = stopAtAttempts<Unit>(5)
+        var attempts = 0
+
+        assertFailsWith<CancellationException> {
+            retry(fiveTimes) {
+                attempts++
+
+                if (attempts == 2) {
+                    throw CancellationException()
+                } else {
+                    Either.Left(Unit)
+                }
+            }
+        }
+
+        assertEquals(2, attempts)
+    }
+
+    @Test
+    fun retryWithCustomPolicy() = runTest {
+        val uptoFifteenTimes = continueIf<AttemptsError> { (failure) ->
+            failure.attempts < 15
+        }
+
+        var attempts = 0
+
+        val result = retry(uptoFifteenTimes) {
+            attempts++
+            Either.Left(AttemptsError(attempts))
+        }
+
+        assertEquals(Either.Left(AttemptsError(15)), result)
+    }
+
+    @Test
+    fun cancelRetryFromJob() = runTest {
+        val every100ms = constantDelay<AttemptsError>(100)
+        var attempts = 0
+
+        val job = backgroundScope.launch {
+            retry(every100ms) {
+                attempts++
+                Either.Left(AttemptsError(attempts))
+            }
+        }
+
+        testScheduler.advanceTimeBy(350)
+        testScheduler.runCurrent()
+
+        job.cancel()
+
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(job.isCancelled)
+        assertEquals(4, attempts)
+
+        testScheduler.advanceTimeBy(2000)
+        testScheduler.runCurrent()
+
+        assertTrue(job.isCancelled)
+        assertEquals(4, attempts)
+    }
+
+    @Test
+    fun cancelRetryWithinJob() = runTest {
+        val every20ms = constantDelay<AttemptsError>(20)
+        var attempts = 0
+
+        val job = launch {
+            retry(every20ms) {
+                attempts++
+
+                if (attempts == 15) {
+                    cancel()
+                }
+
+                Either.Left(AttemptsError(attempts))
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(job.isCancelled)
+        assertEquals(15, attempts)
+
+        testScheduler.advanceTimeBy(2000)
+        testScheduler.runCurrent()
+
+        assertTrue(job.isCancelled)
+        assertEquals(15, attempts)
+    }
+
+    @Test
+    fun cancelRetryWithinChildJob() = runTest {
+        val every20ms = constantDelay<AttemptsError>(20)
+        var attempts = 0
+
+        lateinit var childJobOne: Deferred<Int>
+        lateinit var childJobTwo: Deferred<Int>
+
+        val parentJob = launch {
+            retry(every20ms) {
+                childJobOne = async {
+                    delay(100)
+                    attempts
+                }
+
+                childJobTwo = async {
+                    delay(50)
+
+                    if (attempts == 15) {
+                        cancel()
+                    }
+
+                    1
+                }
+
+                attempts = childJobOne.await() + childJobTwo.await()
+
+                Either.Left(AttemptsError(attempts))
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(parentJob.isCancelled)
+        assertFalse(childJobOne.isCancelled)
+        assertTrue(childJobTwo.isCancelled)
+        assertEquals(15, attempts)
+
+        testScheduler.advanceTimeBy(2000)
+        testScheduler.runCurrent()
+
+        assertTrue(parentJob.isCancelled)
+        assertFalse(childJobOne.isCancelled)
+        assertTrue(childJobTwo.isCancelled)
+        assertEquals(15, attempts)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,3 +19,4 @@ rootProject.name = "kotlin-retry"
 
 include("kotlin-retry")
 include("kotlin-retry-result")
+include("kotlin-retry-either")


### PR DESCRIPTION
For #24 

- add arrow-kt 1.2 to dependency
  - arrow-kt 2.0 or higher versions requires kotlin 2.0 or higher
- add `kotlin-retry-either` subproject
- skip some platform because arrow-kt support



